### PR TITLE
Update the expected string for the new Debug output in 1.52+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ slog = "2.5.0"
 
 [dev-dependencies]
 slog-async = "2.4.0"
+rustversion = "1.0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,9 +212,9 @@ macro_rules! w(
 );
 
 fn can_skip_quoting(ch: char) -> bool {
-    (ch >= 'a' && ch <= 'z')
-        || (ch >= 'A' && ch <= 'Z')
-        || (ch >= '0' && ch <= '9')
+    ('a'..='z').contains(&ch)
+        || ('A'..='Z').contains(&ch)
+        || ('0'..='9').contains(&ch)
         || ch == '-'
         || ch == '.'
         || ch == '_'
@@ -349,7 +349,7 @@ where
         if self.options.print_msg {
             record.msg().serialize(
                 record,
-                #[allow(clippy::identity_conversion)] // necessary for dynamic-keys
+                #[allow(clippy::useless_conversion)] // necessary for dynamic-keys
                 "msg".into(),
                 &mut serializer,
             )?;

--- a/tests/simple_output.rs
+++ b/tests/simple_output.rs
@@ -42,10 +42,16 @@ fn write_stuff() {
     debug!(logger, #"testing_tag", "hi there"; "foo" => "bar'baz\"");
 
     drop(logger);
-    assert_eq!(
-        output.snapshot_str(),
+
+    #[rustversion::before(1.52)]
+    fn expected() -> &'static str {
         "DEBG | #testing_tag\thi there\tlogger=tests foo=\"bar\\\'baz\\\"\"\n"
-    );
+    }
+    #[rustversion::since(1.52)]
+    fn expected() -> &'static str {
+        "DEBG | #testing_tag\thi there\tlogger=tests foo=\"bar'baz\\\"\"\n"
+    }
+    assert_eq!(output.snapshot_str(), expected());
 }
 
 #[test]
@@ -57,10 +63,17 @@ fn force_quotes() {
     debug!(logger, #"testing_tag", "hi there"; "foo" => "bar'baz\"");
 
     drop(logger);
-    assert_eq!(
-        output.snapshot_str(),
-        "DEBG | #testing_tag\thi there\tlogger=\"tests\" foo=\"bar\\\'baz\\\"\"\n"
-    );
+
+    #[rustversion::before(1.52)]
+    fn expected() -> &'static str {
+        "DEBG | #testing_tag\thi there\tlogger=\"tests\" foo=\"bar\\'baz\\\"\"\n"
+    }
+    #[rustversion::since(1.52)]
+    fn expected() -> &'static str {
+        "DEBG | #testing_tag\thi there\tlogger=\"tests\" foo=\"bar'baz\\\"\"\n"
+    }
+
+    assert_eq!(output.snapshot_str(), expected());
 }
 
 struct PrefixSerializer<W: io::Write> {


### PR DESCRIPTION
New nightly has updated its quote mark escaping rules and now no
longer escapes single quotes. Since that's not guaranteed stable, we
have to deal.